### PR TITLE
[Clean diff] Support file paths for model_config in langchain

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh
-          pip install pyspark
+          pip install pyspark langchain
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |
@@ -356,6 +356,6 @@ jobs:
           pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
             --ignore-flavors --ignore=tests/projects --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate --ignore tests/deployments/server \
             tests
-          # MLeap is incompatible on Windows with PySpark3.4 release. 
+          # MLeap is incompatible on Windows with PySpark3.4 release.
           # Reinstate tests when MLeap has released a fix. [ML-30491]
           # pytest tests/mleap

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -68,6 +68,7 @@ promptlab = LazyLoader("mlflow.promptlab", globals(), "mlflow.promptlab")
 pyfunc = LazyLoader("mlflow.pyfunc", globals(), "mlflow.pyfunc")
 pyspark = LazyLoader("mlflow.pyspark", globals(), "mlflow.pyspark")
 pytorch = LazyLoader("mlflow.pytorch", globals(), "mlflow.pytorch")
+rfunc = LazyLoader("mlflow.rfunc", globals(), "mlflow.rfunc")
 recipes = LazyLoader("mlflow.recipes", globals(), "mlflow.recipes")
 sentence_transformers = LazyLoader(
     "mlflow.sentence_transformers",
@@ -194,6 +195,7 @@ __all__ = [
     "log_table",
     "log_text",
     "login",
+    "pyfunc",
     "register_model",
     "run",
     "search_experiments",

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -336,7 +336,7 @@ def save_model(
         )
         model_data_kwargs = {}
 
-    # TODO: add model_config is file path support to pyfunc
+    # TODO: Pass file paths for model_config when it is supported in pyfunc
     pyfunc.add_to_model(
         mlflow_model,
         loader_module="mlflow.langchain",
@@ -346,7 +346,7 @@ def save_model(
         predict_stream_fn="predict_stream",
         streamable=streamable,
         model_code=model_code_dir_subpath,
-        model_config=model_config,
+        model_config=None if isinstance(model_config, str) else model_config,
         **model_data_kwargs,
     )
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -82,7 +82,6 @@ from mlflow.utils.environment import (
 from mlflow.utils.file_utils import get_total_file_size, write_to
 from mlflow.utils.model_utils import (
     FLAVOR_CONFIG_CODE,
-    FLAVOR_CONFIG_MODEL_CODE,
     _add_code_from_conf_to_system_path,
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
@@ -854,10 +853,9 @@ def _load_model_from_local_fs(local_model_path):
             config_path = None
 
         flavor_code_path = flavor_conf.get(_CODE_PATH, "chain.py")
-        flavor_model_code_config = flavor_conf.get(FLAVOR_CONFIG_MODEL_CODE)
         code_path = os.path.join(
             local_model_path,
-            flavor_model_code_config,
+            flavor_code_config,
             os.path.basename(flavor_code_path),
         )
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -241,12 +241,15 @@ def save_model(
     _validate_and_prepare_target_save_path(path)
 
     model_config_path = None
+    model_code_path = None
     if isinstance(lc_model, str):
         # The LangChain model is defined as Python code located in the file at the path
         # specified by `lc_model`. Verify that the path exists and, if so, copy it to the
         # model directory along with any other specified code modules
 
-        if not os.path.exists(lc_model):
+        if os.path.exists(lc_model):
+            model_code_path = lc_model
+        else:
             raise mlflow.MlflowException.invalid_parameter_value(
                 f"If the provided model '{lc_model}' is a string, it must be a valid python "
                 "file path or a databricks notebook file path containing the code for defining "
@@ -347,7 +350,7 @@ def save_model(
         code=code_dir_subpath,
         predict_stream_fn="predict_stream",
         streamable=streamable,
-        model_code=model_code_dir_subpath,
+        model_code=model_code_path,
         model_config=None if isinstance(model_config, str) else model_config,
         **model_data_kwargs,
     )
@@ -369,7 +372,8 @@ def save_model(
         FLAVOR_NAME,
         langchain_version=langchain.__version__,
         code=code_dir_subpath,
-        model_code=model_code_dir_subpath,
+        model_code=model_code_path,
+        model_config=model_config_path,
         streamable=streamable,
         **flavor_conf,
     )

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -96,6 +96,7 @@ _MODEL_TYPE_KEY = "model_type"
 _MODEL_CODE_CONFIG = "model_config"
 _MODEL_CODE_PATH = "model_code_path"
 
+
 def get_default_pip_requirements():
     """
     Returns:
@@ -236,7 +237,7 @@ def save_model(
 
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
-    
+
     model_code_paths = None
     model_config_path = None
     if isinstance(lc_model, str):
@@ -252,7 +253,7 @@ def save_model(
                 "file path or a databricks notebook file path containing the code for defining "
                 "the chain instance."
             )
-        
+
         if isinstance(model_config, str):
             if os.path.exists(model_config):
                 model_config_path = model_config
@@ -267,10 +268,9 @@ def save_model(
             # for backwards compatibility
             if len(code_paths) == 1 and os.path.exists(code_paths[0]):
                 model_config_path = model_config
-        
+
         if model_config_path:
             model_code_paths.append(model_config_path)
-
 
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
     model_code_dir_subpath = _validate_and_copy_model_code_paths(model_code_paths, path)

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -54,8 +54,9 @@ from mlflow.langchain.utils import (
 )
 from mlflow.models import Model, ModelInputExample, ModelSignature, get_model_info
 from mlflow.models.model import MLMODEL_FILE_NAME
+from mlflow.models.model_config import _set_model_config
 from mlflow.models.signature import _infer_signature_from_input_example
-from mlflow.models.utils import _save_example, _set_model_config
+from mlflow.models.utils import _save_example
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.schema import ColSpec, DataType, Schema

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -40,7 +40,7 @@ from mlflow.models.evaluation import (
     make_metric,
 )
 from mlflow.models.flavor_backend import FlavorBackend
-from mlflow.models.model import Model, get_model_info
+from mlflow.models.model import Model, get_model_info, set_model
 from mlflow.models.model_config import ModelConfig
 from mlflow.models.python_api import build_docker
 from mlflow.utils.environment import infer_pip_requirements
@@ -55,6 +55,7 @@ __all__ = [
     "EvaluationArtifact",
     "EvaluationResult",
     "get_model_info",
+    "set_model",
     "list_evaluators",
     "MetricThreshold",
     "build_docker",

--- a/mlflow/models/flavor_backend_registry.py
+++ b/mlflow/models/flavor_backend_registry.py
@@ -18,19 +18,20 @@ _logger = logging.getLogger(__name__)
 
 
 def _get_flavor_backend_for_local_model(model=None, build_docker=True, **kwargs):
-    from mlflow import pyfunc
+    from mlflow import pyfunc, rfunc
     from mlflow.pyfunc.backend import PyFuncBackend
     from mlflow.rfunc.backend import RFuncBackend
 
     if not model:
         return pyfunc.FLAVOR_NAME, PyFuncBackend({}, **kwargs)
 
-    _flavor_backends = {pyfunc.FLAVOR_NAME: PyFuncBackend, "crate": RFuncBackend}
-    for flavor_name, flavor_config in model.flavors.items():
-        if flavor_name in _flavor_backends:
-            backend = _flavor_backends[flavor_name](flavor_config, **kwargs)
-            if build_docker and backend.can_build_image() or backend.can_score_model():
-                return flavor_name, backend
+    backends = {pyfunc.FLAVOR_NAME: PyFuncBackend, rfunc.FLAVOR_NAME: RFuncBackend}
+    for flavor, Backend in backends.items():
+        if flavor in model.flavors:
+            backend = Backend(model.flavors[flavor], **kwargs)
+            if (build_docker and backend.can_build_image()) or backend.can_score_model():
+                return flavor, backend
+
     return None, None
 
 

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -836,3 +836,30 @@ def update_model_requirements(
     _logger.info(f"Uploading updated requirements files to {resolved_uri}...")
     _upload_artifact_to_uri(conda_yaml_path, resolved_uri)
     _upload_artifact_to_uri(requirements_txt_path, resolved_uri)
+
+
+__mlflow_model__ = None
+
+
+def set_model(model):
+    """
+    When logging model as code, this function can be used to set the model object
+    to be logged.
+
+    Args:
+        model: The model object to be logged.
+    """
+    from mlflow.pyfunc import PythonModel
+
+    if not isinstance(model, PythonModel):
+        try:
+            from mlflow.langchain import _validate_and_wrap_lc_model
+
+            # If its not a PyFuncModel, then it should be a Langchain model
+            _validate_and_wrap_lc_model(model, None)
+        except Exception as e:
+            raise mlflow.MlflowException(
+                "Model should either be an instance of PyFuncModel or Langchain type."
+            ) from e
+
+    globals()["__mlflow_model__"] = model

--- a/mlflow/models/model_config.py
+++ b/mlflow/models/model_config.py
@@ -5,6 +5,7 @@ import yaml
 
 __mlflow_model_config__ = None
 
+
 # Should we allow ModelConfig to take in dict?
 class ModelConfig:
     """
@@ -47,7 +48,7 @@ class ModelConfig:
             return config_data[key]
         else:
             raise KeyError(f"Key '{key}' not found in configuration: {config_data}.")
-        
+
 
 def _set_model_config(model_config):
     globals()["__mlflow_model_config__"] = model_config

--- a/mlflow/models/model_config.py
+++ b/mlflow/models/model_config.py
@@ -3,9 +3,9 @@ from typing import Optional
 
 import yaml
 
-import mlflow
+__mlflow_model_config__ = None
 
-
+# Should we allow ModelConfig to take in dict?
 class ModelConfig:
     """
     ModelConfig used in code to read a YAML configuration file, and this configuration file can be
@@ -13,11 +13,8 @@ class ModelConfig:
     """
 
     def __init__(self, *, development_config: Optional[str] = None):
-        # TODO: Update global path after we pass in paths using model_config
-        _mlflow_rag_config_path = getattr(
-            mlflow.langchain._rag_utils, "__databricks_rag_config_path__", None
-        )
-        self.config_path = _mlflow_rag_config_path or development_config
+        config = globals().get("__mlflow_model_config__", None)
+        self.config_path = config or development_config
 
         if not self.config_path:
             raise FileNotFoundError("Config file is None. Please provide a valid path.")
@@ -50,3 +47,7 @@ class ModelConfig:
             return config_data[key]
         else:
             raise KeyError(f"Key '{key}' not found in configuration: {config_data}.")
+        
+
+def _set_model_config(model_config):
+    globals()["__mlflow_model_config__"] = model_config

--- a/mlflow/models/model_config.py
+++ b/mlflow/models/model_config.py
@@ -15,7 +15,9 @@ class ModelConfig:
 
     def __init__(self, *, development_config: Optional[str] = None):
         config = globals().get("__mlflow_model_config__", None)
-        self.config_path = config or development_config
+        # backwards compatibility
+        rag_config = globals().get("__databricks_rag_config_path__", None)
+        self.config_path = config or rag_config or development_config
 
         if not self.config_path:
             raise FileNotFoundError("Config file is None. Please provide a valid path.")

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -88,7 +88,6 @@ _logger = logging.getLogger(__name__)
 
 _FEATURE_STORE_FLAVOR = "databricks.feature_store.mlflow_model"
 
-
 def _is_scalar(x):
     return np.isscalar(x) or x is None
 
@@ -1389,7 +1388,3 @@ def convert_complex_types_pyspark_to_pandas(value, dataType):
     if converter:
         return converter(value)
     return value
-
-
-def _set_model_config(model_config):
-    globals()["__mlflow_model_config__"] = model_config

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -1389,3 +1389,7 @@ def convert_complex_types_pyspark_to_pandas(value, dataType):
     if converter:
         return converter(value)
     return value
+
+
+def _set_model_config(model_config):
+    globals()["__mlflow_model_config__"] = model_config

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -88,6 +88,7 @@ _logger = logging.getLogger(__name__)
 
 _FEATURE_STORE_FLAVOR = "databricks.feature_store.mlflow_model"
 
+
 def _is_scalar(x):
     return np.isscalar(x) or x is None
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -667,7 +667,6 @@ class PyFuncModel:
                 )
 
         params = _validate_params(params, self.metadata)
-        _log_warning_if_params_not_in_predict_signature(_logger, params)
         if HAS_PYSPARK and isinstance(data, SparkDataFrame):
             _logger.warning(
                 "Input data is a Spark DataFrame. Note that behaviour for "
@@ -707,6 +706,8 @@ class PyFuncModel:
         data, params = self._validate_prediction_input(data, params)
         if inspect.signature(self._predict_fn).parameters.get("params"):
             return self._predict_fn(data, params=params)
+
+        _log_warning_if_params_not_in_predict_signature(_logger, params)
         return self._predict_fn(data)
 
     def predict_stream(
@@ -716,8 +717,10 @@ class PyFuncModel:
             raise MlflowException("This model does not support predict_stream method.")
 
         data, params = self._validate_prediction_input(data, params)
-        if inspect.signature(self._predict_fn).parameters.get("params"):
+        if inspect.signature(self._predict_stream_fn).parameters.get("params"):
             return self._predict_stream_fn(data, params=params)
+
+        _log_warning_if_params_not_in_predict_signature(_logger, params)
         return self._predict_stream_fn(data)
 
     @experimental

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -827,7 +827,7 @@ def load_model(
     model_uri: str,
     suppress_warnings: bool = False,
     dst_path: Optional[str] = None,
-    model_config: Optional[Union[Dict[str, Any], str]] = None,
+    model_config: Optional[Dict[str, Any]] = None,
 ) -> PyFuncModel:
     """
     Load a model stored in Python function format.
@@ -878,7 +878,6 @@ def load_model(
 
     _add_code_from_conf_to_system_path(local_path, conf, code_key=CODE)
     data_path = os.path.join(local_path, conf[DATA]) if (DATA in conf) else local_path
-    # TODO: convert model_config to dict? if it is a file path?
     model_config = _get_overridden_pyfunc_model_config(
         conf.get(MODEL_CONFIG, None), model_config, _logger
     )

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -827,7 +827,7 @@ def load_model(
     model_uri: str,
     suppress_warnings: bool = False,
     dst_path: Optional[str] = None,
-    model_config: Optional[Dict[str, Any]] = None,
+    model_config: Optional[Union[Dict[str, Any], str]] = None,
 ) -> PyFuncModel:
     """
     Load a model stored in Python function format.
@@ -878,6 +878,7 @@ def load_model(
 
     _add_code_from_conf_to_system_path(local_path, conf, code_key=CODE)
     data_path = os.path.join(local_path, conf[DATA]) if (DATA in conf) else local_path
+    # TODO: convert model_config to dict? if it is a file path?
     model_config = _get_overridden_pyfunc_model_config(
         conf.get(MODEL_CONFIG, None), model_config, _logger
     )

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -12,9 +12,9 @@ from pathlib import Path
 
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
-from mlflow.models import FlavorBackend, docker_utils
+from mlflow.models import FlavorBackend, Model, docker_utils
 from mlflow.models.docker_utils import PYTHON_SLIM_BASE_IMAGE, UBUNTU_BASE_IMAGE
-from mlflow.models.model import MLMODEL_FILE_NAME, Model
+from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.pyfunc import (
     ENV,
     _extract_conda_env,
@@ -23,7 +23,7 @@ from mlflow.pyfunc import (
     scoring_server,
 )
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils import env_manager as _EnvManager
+from mlflow.utils import env_manager as em
 from mlflow.utils.conda import get_conda_bin_executable, get_or_create_conda_env
 from mlflow.utils.environment import Environment, _PythonEnv
 from mlflow.utils.file_utils import (
@@ -91,11 +91,11 @@ class PyFuncBackend(FlavorBackend):
         """
         super().__init__(config=config, **kwargs)
         self._nworkers = workers or 1
-        if env_manager == _EnvManager.CONDA and ENV not in config:
+        if env_manager == em.CONDA and ENV not in config:
             warnings.warn(
                 "Conda environment is not specified in config `env`. Using local environment."
             )
-            env_manager = _EnvManager.LOCAL
+            env_manager = em.LOCAL
         self._env_manager = env_manager
         self._install_mlflow = install_mlflow
         self._env_id = os.environ.get("MLFLOW_HOME", VERSION) if install_mlflow else None
@@ -114,9 +114,9 @@ class PyFuncBackend(FlavorBackend):
             else:
                 root_tmp_dir = get_or_create_tmp_dir()
 
-            env_root_dir = os.path.join(root_tmp_dir, "envs")
-            os.makedirs(env_root_dir, exist_ok=True)
-            return env_root_dir
+            envs_root_dir = os.path.join(root_tmp_dir, "envs")
+            os.makedirs(envs_root_dir, exist_ok=True)
+            return envs_root_dir
 
         local_path = _download_artifact_from_uri(model_uri)
         if self._create_env_root_dir:
@@ -127,7 +127,7 @@ class PyFuncBackend(FlavorBackend):
         else:
             env_root_dir = self._env_root_dir
 
-        if self._env_manager == _EnvManager.VIRTUALENV:
+        if self._env_manager == em.VIRTUALENV:
             activate_cmd = _get_or_create_virtualenv(
                 local_path,
                 self._env_id,
@@ -136,7 +136,7 @@ class PyFuncBackend(FlavorBackend):
                 pip_requirements_override=pip_requirements_override,
             )
             self._environment = Environment(activate_cmd)
-        elif self._env_manager == _EnvManager.CONDA:
+        elif self._env_manager == em.CONDA:
             conda_env_path = os.path.join(local_path, _extract_conda_env(self._config[ENV]))
             self._environment = get_or_create_conda_env(
                 conda_env_path,
@@ -146,7 +146,7 @@ class PyFuncBackend(FlavorBackend):
                 pip_requirements_override=pip_requirements_override,
             )
 
-        elif self._env_manager == _EnvManager.LOCAL:
+        elif self._env_manager == em.LOCAL:
             raise Exception("Prepare env should not be called with local env manager!")
         else:
             raise Exception(f"Unexpected env manager value '{self._env_manager}'")
@@ -176,7 +176,7 @@ class PyFuncBackend(FlavorBackend):
         # platform compatibility.
         local_uri = path_to_local_file_uri(local_path)
 
-        if self._env_manager != _EnvManager.LOCAL:
+        if self._env_manager != em.LOCAL:
             predict_cmd = [
                 "python",
                 _mlflow_pyfunc_backend_predict.__file__,
@@ -190,10 +190,10 @@ class PyFuncBackend(FlavorBackend):
             if output_path:
                 predict_cmd += ["--output-path", shlex.quote(str(output_path))]
 
-            if pip_requirements_override and self._env_manager == _EnvManager.CONDA:
+            if pip_requirements_override and self._env_manager == em.CONDA:
                 # Conda use = instead of == for version pinning
                 pip_requirements_override = [
-                    l.replace("==", "=") for l in pip_requirements_override
+                    pip_req.replace("==", "=") for pip_req in pip_requirements_override
                 ]
 
             environment = self.prepare_env(
@@ -281,7 +281,7 @@ class PyFuncBackend(FlavorBackend):
             #  does not support prctl. We need to find an approach to address it.
             command = "exec " + command
 
-        if self._env_manager != _EnvManager.LOCAL:
+        if self._env_manager != em.LOCAL:
             return self.prepare_env(local_path).execute(
                 command,
                 command_env,
@@ -330,7 +330,7 @@ class PyFuncBackend(FlavorBackend):
         )
 
     def can_score_model(self):
-        if self._env_manager == _EnvManager.LOCAL:
+        if self._env_manager == em.LOCAL:
             # noconda => already in python and dependencies are assumed to be installed.
             return True
         conda_path = get_conda_bin_executable("conda")
@@ -387,17 +387,15 @@ class PyFuncBackend(FlavorBackend):
 
             if base_image.startswith("python"):
                 # we can directly use local env for python image
-                env_manager = _EnvManager.LOCAL if self._env_manager is None else self._env_manager
-                if env_manager in [_EnvManager.CONDA, _EnvManager.VIRTUALENV]:
+                env_manager = self._env_manager or em.LOCAL
+                if env_manager in [em.CONDA, em.VIRTUALENV]:
                     # we can directly use ubuntu image for conda and virtualenv
                     base_image = UBUNTU_BASE_IMAGE
             elif base_image == UBUNTU_BASE_IMAGE:
-                env_manager = (
-                    _EnvManager.VIRTUALENV if self._env_manager is None else self._env_manager
-                )
+                env_manager = self._env_manager or em.VIRTUALENV
                 # installing python on ubuntu image is problematic and not recommended officially
-                # so we recommend using conda or virtualenv instead on ubuntu image
-                if env_manager == _EnvManager.LOCAL:
+                # , so we recommend using conda or virtualenv instead on ubuntu image
+                if env_manager == em.LOCAL:
                     raise MlflowException.invalid_parameter_value(LOCAL_ENV_MANAGER_ERROR_MESSAGE)
             # shouldn't reach here but add this so we can validate base_image value above
             else:
@@ -411,8 +409,8 @@ class PyFuncBackend(FlavorBackend):
         # if no model_uri specified, user must use virtualenv or conda env based on ubuntu image
         else:
             base_image = UBUNTU_BASE_IMAGE
-            env_manager = self._env_manager or _EnvManager.VIRTUALENV
-            if env_manager == _EnvManager.LOCAL:
+            env_manager = self._env_manager or em.VIRTUALENV
+            if env_manager == em.LOCAL:
                 raise MlflowException.invalid_parameter_value(LOCAL_ENV_MANAGER_ERROR_MESSAGE)
 
             model_install_steps = ""
@@ -459,13 +457,13 @@ class PyFuncBackend(FlavorBackend):
             return UBUNTU_BASE_IMAGE
 
         # Get Python version from MLmodel
+        model_config_path = os.path.join(model_path, MLMODEL_FILE_NAME)
         try:
-            model_config_path = os.path.join(model_path, MLMODEL_FILE_NAME)
             model = Model.load(model_config_path)
 
             conf = model.flavors[pyfunc.FLAVOR_NAME]
             env_conf = conf[pyfunc.ENV]
-            python_env_config_path = os.path.join(model_path, env_conf[_EnvManager.VIRTUALENV])
+            python_env_config_path = os.path.join(model_path, env_conf[em.VIRTUALENV])
 
             python_env = _PythonEnv.from_yaml(python_env_config_path)
             return PYTHON_SLIM_BASE_IMAGE.format(version=python_env.python)
@@ -497,7 +495,7 @@ class PyFuncBackend(FlavorBackend):
         return steps
 
     def _get_install_pyfunc_deps_cmd(
-        self, env_manager: _EnvManager, install_mlflow: bool, enable_mlserver: bool
+        self, env_manager: str, install_mlflow: bool, enable_mlserver: bool
     ):
         return (
             "from mlflow.models import container as C; "

--- a/mlflow/rfunc/__init__.py
+++ b/mlflow/rfunc/__init__.py
@@ -38,3 +38,5 @@ Example:
       model: r_model.bin
 
 """
+
+FLAVOR_NAME = "crate"

--- a/mlflow/store/artifact/dbfs_artifact_repo.py
+++ b/mlflow/store/artifact/dbfs_artifact_repo.py
@@ -14,7 +14,7 @@ from mlflow.store.tracking.rest_store import RestStore
 from mlflow.tracking._tracking_service import utils
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.file_utils import relative_path_to_artifact_path
-from mlflow.utils.rest_utils import RESOURCE_DOES_NOT_EXIST, http_request, http_request_safe
+from mlflow.utils.rest_utils import RESOURCE_NON_EXISTENT, http_request, http_request_safe
 from mlflow.utils.string_utils import strip_prefix
 from mlflow.utils.uri import (
     get_databricks_profile_uri_from_artifact_uri,
@@ -144,7 +144,7 @@ class DbfsRestArtifactRepository(ArtifactRepository):
         # /api/2.0/dbfs/list will not have the 'files' key in the response for empty directories.
         infos = []
         artifact_prefix = strip_prefix(self.artifact_uri, "dbfs:")
-        if json_response.get("error_code", None) == RESOURCE_DOES_NOT_EXIST:
+        if json_response.get("error_code", None) == RESOURCE_NON_EXISTENT:
             return []
         dbfs_files = json_response.get("files", [])
         for dbfs_file in dbfs_files:

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -20,6 +20,7 @@ from mlflow.utils.file_utils import _copy_file_or_tree
 from mlflow.utils.uri import append_to_uri_path
 
 FLAVOR_CONFIG_CODE = "code"
+FLAVOR_CONFIG_MODEL_CODE = "model_code"
 
 
 def _get_all_flavor_configurations(model_path):
@@ -154,6 +155,20 @@ def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
     return code_dir_subpath
 
 
+def _validate_and_copy_model_code_path(code_path, path, default_subpath="model_code"):
+    """Copies the model code from code_path to a directory.
+
+    Args:
+        code_path: A file containing model code that should be logged as an artifact.
+        path: The local model path.
+        default_subpath: The default directory name used to store model code artifacts.
+    """
+    if code_path:
+        return _validate_and_copy_code_paths([code_path], path, default_subpath)
+    else:
+        return None
+
+
 def _add_code_to_system_path(code_path):
     sys.path = [code_path] + sys.path
 
@@ -209,7 +224,10 @@ def _validate_onnx_session_options(onnx_session_options):
                     f"Value for key {key} in onnx_session_options should be a dict, "
                     "not {type(value)}"
                 )
-            elif key == "execution_mode" and value.upper() not in ["PARALLEL", "SEQUENTIAL"]:
+            elif key == "execution_mode" and value.upper() not in [
+                "PARALLEL",
+                "SEQUENTIAL",
+            ]:
                 raise ValueError(
                     f"Value for key {key} in onnx_session_options should be "
                     f"'parallel' or 'sequential', not {value}"

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -229,10 +229,7 @@ def _validate_onnx_session_options(onnx_session_options):
                     f"Value for key {key} in onnx_session_options should be a dict, "
                     "not {type(value)}"
                 )
-            elif key == "execution_mode" and value.upper() not in [
-                "PARALLEL",
-                "SEQUENTIAL",
-            ]:
+            elif key == "execution_mode" and value.upper() not in ["PARALLEL", "SEQUENTIAL"]:
                 raise ValueError(
                     f"Value for key {key} in onnx_session_options should be "
                     f"'parallel' or 'sequential', not {value}"

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -301,11 +301,6 @@ def _validate_pyfunc_model_config(model_config):
     if not model_config:
         return
 
-    if isinstance(model_config, str):
-        # TODO: check that model_config is a valid path, and can be read. validate that it is yaml?
-        # raise exception if it is not
-        return
-
     if not isinstance(model_config, dict) or not all(isinstance(key, str) for key in model_config):
         raise MlflowException(
             "An invalid ``model_config`` structure was passed. ``model_config`` must be of type "

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -33,15 +33,8 @@ def _get_all_flavor_configurations(model_path):
         The dictionary contains all flavor configurations with flavor name as key.
 
     """
-    model_configuration_path = os.path.join(model_path, MLMODEL_FILE_NAME)
-    if not os.path.exists(model_configuration_path):
-        raise MlflowException(
-            f'Could not find an "{MLMODEL_FILE_NAME}" configuration file at "{model_path}"',
-            RESOURCE_DOES_NOT_EXIST,
-        )
 
-    model_conf = Model.load(model_configuration_path)
-    return model_conf.flavors
+    return Model.load(model_path).flavors
 
 
 def _get_flavor_configuration(model_path, flavor_name):
@@ -58,13 +51,12 @@ def _get_flavor_configuration(model_path, flavor_name):
         The flavor configuration as a dictionary.
 
     """
-    flavors = _get_all_flavor_configurations(model_path)
-    if flavor_name not in flavors:
+    try:
+        return Model.load(model_path).flavors[flavor_name]
+    except KeyError as ex:
         raise MlflowException(
-            f'Model does not have the "{flavor_name}" flavor',
-            RESOURCE_DOES_NOT_EXIST,
-        )
-    return flavors[flavor_name]
+            f'Model does not have the "{flavor_name}" flavor', RESOURCE_DOES_NOT_EXIST
+        ) from ex
 
 
 def _get_flavor_configuration_from_uri(model_uri, flavor_name, logger):

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -303,6 +303,11 @@ def _validate_pyfunc_model_config(model_config):
 
     if not model_config:
         return
+    
+    if isinstance(model_config, str):
+        # TODO: check that model_config is a valid path, and can be read. validate that it is yaml?
+        # raise exception if it is not
+        return
 
     if not isinstance(model_config, dict) or not all(isinstance(key, str) for key in model_config):
         raise MlflowException(

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -20,8 +20,6 @@ from mlflow.utils.file_utils import _copy_file_or_tree
 from mlflow.utils.uri import append_to_uri_path
 
 FLAVOR_CONFIG_CODE = "code"
-FLAVOR_CONFIG_MODEL_CODE = "model_code"
-
 
 def _get_all_flavor_configurations(model_path):
     """Obtains all the flavor configurations from the specified MLflow model path.
@@ -163,15 +161,46 @@ def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
     return code_dir_subpath
 
 
-def _validate_and_copy_model_code_paths(code_paths, path, default_subpath="model_code"):
+def _validate_path_exists(path, name):
+    if path and not os.path.exists(path):
+        raise MlflowException(
+            message=(
+                f"Failed to copy the specified {name} path '{path}' into the model "
+                f"artifacts. The specified {name }path does not exist. Please specify a valid "
+                f"{name} path and try again."
+            ),
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+
+
+def _validate_and_copy_model_code_and_config_paths(code_path, config_path, path):
     """Copies the model code from code_path to a directory.
 
     Args:
         code_path: A file containing model code that should be logged as an artifact.
+        config_path: A file containing model config code that should be logged as an artifact.
         path: The local model path.
-        default_subpath: The default directory name used to store model code artifacts.
     """
-    return _validate_and_copy_code_paths(code_paths, path, default_subpath)
+    _validate_path_exists(code_path, "code")
+    _validate_path_exists(config_path, "config")
+    try:
+        _copy_file_or_tree(src=code_path, dst=path)
+        if config_path:
+            _copy_file_or_tree(src=config_path, dst=path)
+    except OSError as e:
+        # A common error is code-paths includes Databricks Notebook. We include it in error
+        # message when running in Databricks, but not in other envs tp avoid confusion.
+        example = ", such as Databricks Notebooks" if is_in_databricks_runtime() else ""
+        raise MlflowException(
+            message=(
+                f"Failed to copy the specified code path '{code_path}' into the model "
+                "artifacts. It appears that your code path includes file(s) that cannot "
+                f"be copied{example}. Please specify a code path that does not include "
+                "such files and try again.",
+            ),
+            error_code=INVALID_PARAMETER_VALUE,
+        ) from e
 
 
 def _add_code_to_system_path(code_path):

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -300,7 +300,7 @@ def _validate_pyfunc_model_config(model_config):
 
     if not model_config:
         return
-    
+
     if isinstance(model_config, str):
         # TODO: check that model_config is a valid path, and can be read. validate that it is yaml?
         # raise exception if it is not

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -163,7 +163,7 @@ def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
     return code_dir_subpath
 
 
-def _validate_and_copy_model_code_path(code_path, path, default_subpath="model_code"):
+def _validate_and_copy_model_code_paths(code_paths, path, default_subpath="model_code"):
     """Copies the model code from code_path to a directory.
 
     Args:
@@ -171,10 +171,7 @@ def _validate_and_copy_model_code_path(code_path, path, default_subpath="model_c
         path: The local model path.
         default_subpath: The default directory name used to store model code artifacts.
     """
-    if code_path:
-        return _validate_and_copy_code_paths([code_path], path, default_subpath)
-    else:
-        return None
+    return _validate_and_copy_code_paths(code_paths, path, default_subpath)
 
 
 def _add_code_to_system_path(code_path):

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -30,7 +30,7 @@ from mlflow.utils.request_utils import (
 )
 from mlflow.utils.string_utils import strip_suffix
 
-RESOURCE_DOES_NOT_EXIST = "RESOURCE_DOES_NOT_EXIST"
+RESOURCE_NON_EXISTENT = "RESOURCE_DOES_NOT_EXIST"
 _REST_API_PATH_PREFIX = "/api/2.0"
 
 

--- a/tests/langchain/chain.py
+++ b/tests/langchain/chain.py
@@ -53,7 +53,7 @@ def get_fake_chat_model(endpoint="fake-endpoint"):
     return FakeChatModel(endpoint=endpoint)
 
 
-config_path = mlflow.langchain._rag_utils.__databricks_rag_config_path__
+config_path = mlflow.models.model_config.__mlflow_model_config__
 assert os.path.exists(config_path)
 
 with open(config_path) as f:

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1,7 +1,6 @@
 import importlib
 import json
 import os
-import re
 import shutil
 import sqlite3
 from contextlib import contextmanager
@@ -12,7 +11,6 @@ from unittest import mock
 import langchain
 import numpy as np
 import openai
-import mlflow.models.model
 import pytest
 import transformers
 import yaml
@@ -48,6 +46,7 @@ from pydantic import BaseModel
 from pyspark.sql import SparkSession
 
 import mlflow
+import mlflow.models.model
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.deployments import PredictionsResponse
 from mlflow.exceptions import MlflowException

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2346,9 +2346,9 @@ def test_save_load_chain_as_code(chain_model_signature):
             model_config="tests/langchain/config.yml",
         )
 
-    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ is None
+    assert mlflow.models.model_config.__mlflow_model_config__ is None
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
-    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ is None
+    assert mlflow.models.model_config.__mlflow_model_config__  is None
     answer = "Databricks"
     assert loaded_model.invoke(input_example) == answer
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
@@ -2516,9 +2516,9 @@ def test_save_load_chain_as_code_optional_code_path(chain_model_signature):
             input_example=input_example,
         )
 
-    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ is None
+    assert mlflow.models.model_config.__mlflow_model_config__  is None
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
-    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ is None
+    assert mlflow.models.model_config.__mlflow_model_config__  is None
     answer = "Databricks"
     assert loaded_model.invoke(input_example) == answer
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)

--- a/tests/models/configs/config.yaml
+++ b/tests/models/configs/config.yaml
@@ -1,5 +1,5 @@
 embedding_model_query_instructions: "Represent this sentence for searching relevant passages:"
-llm_model: "databricks-mixtral-8x7b-instruct"
+llm_model: "databricks-dbrx-instruct"
 llm_prompt_template: "You are a trustful assistant."
 retriever_config:
   k: 5

--- a/tests/models/configs/config_2.yaml
+++ b/tests/models/configs/config_2.yaml
@@ -1,5 +1,5 @@
 embedding_model_query_instructions: "Represent this sentence for searching relevant passages:"
-llm_model: "databricks-mixtral-8x7b-instruct"
+llm_model: "databricks-dbrx-instruct"
 llm_prompt_template: "You are a trustful assistant. Answer concisely and clearly."
 retriever_config:
   k: 5

--- a/tests/models/test_model_config.py
+++ b/tests/models/test_model_config.py
@@ -18,9 +18,9 @@ def test_config_not_set():
         ModelConfig()
 
 
-@mock.patch("mlflow.langchain._rag_utils")
+@mock.patch("mlflow.models.model_config")
 def test_config_not_found(mock_rag_config_path):
-    mock_rag_config_path.__databricks_rag_config_path__ = "nonexistent.yaml"
+    mock_rag_config_path.__mlflow_model_config__ = "nonexistent.yaml"
     with pytest.raises(FileNotFoundError, match="Config file 'nonexistent.yaml' not found."):
         ModelConfig(development_config="nonexistent.yaml")
 
@@ -44,20 +44,20 @@ def test_config_setup_correctly():
     assert config.get("llm_parameters").get("temperature") == 0.01
 
 
-@mock.patch("mlflow.langchain._rag_utils")
+@mock.patch("mlflow.models.model_config")
 def test_config_setup_correctly_with_mlflow_langchain(mock_rag_config_path):
-    mock_rag_config_path.__databricks_rag_config_path__ = VALID_CONFIG_PATH
+    mock_rag_config_path.__mlflow_model_config__ = VALID_CONFIG_PATH
     config = ModelConfig(development_config="nonexistent.yaml")
     assert config.get("llm_parameters").get("temperature") == 0.01
 
 
-@mock.patch("mlflow.langchain._rag_utils")
+@mock.patch("mlflow.models.model_config")
 def test_config_setup_with_mlflow_langchain_path(mock_rag_config_path):
-    mock_rag_config_path.__databricks_rag_config_path__ = VALID_CONFIG_PATH_2
+    mock_rag_config_path.__mlflow_model_config__ = VALID_CONFIG_PATH_2
     config = ModelConfig(development_config=VALID_CONFIG_PATH)
     # here the config.yaml has the max_tokens set to 500
     # where as the config_2.yaml has it set to 200.
-    # Here we give preference to the __databricks_rag_config_path__.
+    # Here we give preference to the __mlflow_model_config__.
     assert config.get("llm_parameters").get("max_tokens") == 200
 
 

--- a/tests/models/test_model_config.py
+++ b/tests/models/test_model_config.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 
 from mlflow.models import ModelConfig
+import mlflow
 
 dir_path = os.path.dirname(os.path.abspath(__file__))
 VALID_CONFIG_PATH = os.path.join(dir_path, "configs/config.yaml")
@@ -18,9 +19,7 @@ def test_config_not_set():
         ModelConfig()
 
 
-@mock.patch("mlflow.models.model_config")
-def test_config_not_found(mock_rag_config_path):
-    mock_rag_config_path.__mlflow_model_config__ = "nonexistent.yaml"
+def test_config_not_found():
     with pytest.raises(FileNotFoundError, match="Config file 'nonexistent.yaml' not found."):
         ModelConfig(development_config="nonexistent.yaml")
 
@@ -44,20 +43,18 @@ def test_config_setup_correctly():
     assert config.get("llm_parameters").get("temperature") == 0.01
 
 
-@mock.patch("mlflow.models.model_config")
-def test_config_setup_correctly_with_mlflow_langchain(mock_rag_config_path):
-    mock_rag_config_path.__mlflow_model_config__ = VALID_CONFIG_PATH
+@mock.patch("mlflow.models.model_config.__mlflow_model_config__", new=VALID_CONFIG_PATH)
+def test_config_setup_correctly_with_mlflow_langchain():
     config = ModelConfig(development_config="nonexistent.yaml")
     assert config.get("llm_parameters").get("temperature") == 0.01
 
 
-@mock.patch("mlflow.models.model_config")
-def test_config_setup_with_mlflow_langchain_path(mock_rag_config_path):
-    mock_rag_config_path.__mlflow_model_config__ = VALID_CONFIG_PATH_2
-    config = ModelConfig(development_config=VALID_CONFIG_PATH)
+@mock.patch("mlflow.models.model_config.__mlflow_model_config__", new=VALID_CONFIG_PATH_2)
+def test_config_setup_with_mlflow_langchain_path():
     # here the config.yaml has the max_tokens set to 500
     # where as the config_2.yaml has it set to 200.
     # Here we give preference to the __mlflow_model_config__.
+    config = ModelConfig(development_config=VALID_CONFIG_PATH)
     assert config.get("llm_parameters").get("max_tokens") == 200
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/annzhang-db/mlflow/pull/1?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/1/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 1
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
